### PR TITLE
This seems to resolve the "LocalProtocolError: Max outbound streams is n, n open" error

### DIFF
--- a/apt_mirror/download/protocols/http.py
+++ b/apt_mirror/download/protocols/http.py
@@ -22,9 +22,9 @@ class HTTPDownloader(Downloader):
             base_url += "/"
 
         http_limits = httpx.Limits(
-            max_connections=256,
-            max_keepalive_connections=32,
-            keepalive_expiry=5,
+            max_connections=16,
+            max_keepalive_connections=4,
+            keepalive_expiry=1,
         )
 
         client_certificate = None
@@ -68,6 +68,7 @@ class HTTPDownloader(Downloader):
             follow_redirects=True,
             mounts=proxy_mounts,
             max_redirects=5,
+            limits=http_limits,
             headers={
                 "Accept-Encoding": "identity",
                 "Cache-Control": "no-cache",


### PR DESCRIPTION
It looks like http_limits wasn't passed to httpx, except I think in the case of proxy transports. I changed limits and kept seeing the error until I passed the limits explicitly. I also rebooted which I see searchXG people said was necessary to clear the h2 pool.

I don't think this is the full fix as https://github.com/encode/httpcore/pull/1088 looks like it fixes the core issue but hasn't been merged yet. I have just reduced max connections to 16 which fixes my case.

Only submitting in case you missed passing the http_limits argument and I haven't misunderstood the code.